### PR TITLE
Updated speed comparison for hw1 - all are comparable

### DIFF
--- a/Homework/hw1/Trevor_Kolby/hw1.jl
+++ b/Homework/hw1/Trevor_Kolby/hw1.jl
@@ -32,8 +32,8 @@ function newtons(E_0::Float64,e::Float64,m::Float64;delta=1e-12)
     dE = 1.
     while abs(dE)>delta
         E_old = E_new
-#        E_new = E_old - (f(E_old,e,m)/f_prime(E_old,e))
-        E_new = E_old -  (E_old - e*sin(E_old) - m)/(1.0 - e*cos(E_old))
+        E_new = E_old - (g(E_old,e,m)/g_prime(E_old,e))
+#        E_new = E_old -  (E_old - e*sin(E_old) - m)/(1.0 - e*cos(E_old))
         dE = E_new-E_old
     end
     


### PR DESCRIPTION
The latest speed comparison indicates that all codes run at about the same speed.  My takeaways from this are: 1). the quartic solver is not necessarily faster; if anything a bit slower with the 10^-12 tolerance. 2). I would be interested in getting opinions as to which code is the easiest to read and understand - that might be worth using rather than the kepler_solve.jl.

Nice work all!

-Eric
